### PR TITLE
Increased required macOS version to v11

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,8 +6,8 @@ import PackageDescription
 let package = Package(
     name: "core",
     platforms: [
-        .iOS(.v14)
-//        .macOS(.v10_15)
+        .iOS(.v14),
+        .macOS(.v11)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/Sources/Core/KeyValueStorage/Keychain/Keychain.swift
+++ b/Sources/Core/KeyValueStorage/Keychain/Keychain.swift
@@ -5,10 +5,10 @@
 //  Created by Martin Troup on 04.09.2021.
 //
 
+import Foundation
 import Overture
 import OvertureOperators
 import Security
-import UIKit
 
 public struct KeychainErrorMessage: Error, CustomDebugStringConvertible {
     public let value: String?


### PR DESCRIPTION
The version needs to be increased, because Combine Ext minimal macOS version is 10.12. SPM is by default 10.10